### PR TITLE
Make menu close animation play nice on iOS 8

### DIFF
--- a/DropdownMenu/DropdownMenuController.m
+++ b/DropdownMenu/DropdownMenuController.m
@@ -103,6 +103,7 @@ CAShapeLayer *closedMenuShape;
 
 - (void) showMenu {
     self.menu.hidden = NO;
+    self.menu.translatesAutoresizingMaskIntoConstraints = YES;
     
     [closedMenuShape removeFromSuperlayer];
     


### PR DESCRIPTION
The menu jumps when closing it on iOS 8, this fixes it.